### PR TITLE
Make `pod spec lint` pass

### DIFF
--- a/xDripG5.podspec
+++ b/xDripG5.podspec
@@ -14,7 +14,7 @@ Please note this project is neither created nor backed by Dexcom, Inc. Use of th
   s.homepage         = "https://github.com/LoopKit/xDripG5"
   s.license          = 'MIT'
   s.author           = { "Nathan Racklyeft" => "loudnate@gmail.com" }
-  s.source           = { :git => "https://github.com/LoopKit/xDripG5.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/LoopKit/xDripG5.git", :tag => "v" + s.version.to_s }
 
   s.platform     = :ios, '9.3'
   s.requires_arc = true


### PR DESCRIPTION
I think this will fix #50. See the comments I made there about how this might effect legacy versions though.

After changing the podspec in this way `pod trunk push xDripG5.podspec` will still need to be run in order to update the Cocoapods repo.