### PR TITLE
Auth bug fixes

### DIFF
--- a/xDripG5/AESCrypt.m
+++ b/xDripG5/AESCrypt.m
@@ -13,7 +13,7 @@
 
 + (NSData *)encryptData:(NSData *)data usingKey:(NSData *)key error:(NSError * _Nullable __autoreleasing *)error
 {
-    NSMutableData *dataOut = [[NSMutableData alloc] initWithCapacity:16];
+    NSMutableData *dataOut = [NSMutableData dataWithLength: data.length + kCCBlockSizeAES128];
 
     CCCryptorStatus status = CCCrypt(kCCEncrypt,
                                      kCCAlgorithmAES,

--- a/xDripG5/Messages/AuthRequestTxMessage.swift
+++ b/xDripG5/Messages/AuthRequestTxMessage.swift
@@ -19,7 +19,7 @@ struct AuthRequestTxMessage: TransmitterTxMessage {
 
         NSUUID().getBytes(&UUIDBytes)
 
-        singleUseToken = Data(bytes: UUIDBytes)
+        singleUseToken = Data(bytes: UUIDBytes[0..<8])
     }
 
     var byteSequence: [Any] {


### PR DESCRIPTION
Fixes a few bugs when authenticating with the transmitter. AES encryption wasn't working (always returning nil), and AuthRequestTX was sending too many bytes for the singleUseToken.