### PR TITLE
Authenticate with transmitter every time

### DIFF
--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -143,7 +143,7 @@ class BluetoothManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate
      */
     fileprivate func scanAfterDelay() {
         DispatchQueue.global(qos: DispatchQoS.QoSClass.utility).async {
-            Thread.sleep(forTimeInterval: 2)
+            Thread.sleep(forTimeInterval: 10)
 
             self.scanForPeripheral()
         }


### PR DESCRIPTION
Seems to fix #55; with this change I can consistently get readings from the transmitter with passiveMode set to false.

Still some interesting issues: 

- the first time the transmitter connects it seems to timeout in auth somewhere
- every session with the transmitter the final disconnect tx message seems to be timing out
- every session with the transmitter I see `[CoreBluetooth] WARNING: Unknown error: 913` in the console

I also wonder if authenticating every time with the transmitter could reduce transmitter battery life. So use at your own risk!