### PR TITLE
fix some issues with authentication and bonding

### DIFF
--- a/Example/xDripG5/AppDelegate.swift
+++ b/Example/xDripG5/AppDelegate.swift
@@ -54,7 +54,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
     func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 
-        transmitter?.resumeScanning()
+        if let transmitter = transmitter , !transmitter.stayConnected {
+            transmitter.resumeScanning()
+        }
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -106,7 +106,7 @@ class BluetoothManager: NSObject {
         #endif
 
         if let peripheralID = self.peripheral?.identifier, let peripheral = manager.retrievePeripherals(withIdentifiers: [peripheralID]).first {
-            log.info("Re-connecting to known peripheral %{public}@ in %zds", peripheral.identifier.uuidString, delay)
+            log.info("Re-connecting to known peripheral %{public}@ in %.1f s", peripheral.identifier.uuidString, delay)
             self.peripheral = peripheral
             self.manager.connect(peripheral, options: connectOptions)
         } else if let peripheral = manager.retrieveConnectedPeripherals(withServices: [

--- a/xDripG5/PeripheralManager+G5.swift
+++ b/xDripG5/PeripheralManager+G5.swift
@@ -65,12 +65,14 @@ extension PeripheralManager {
             peripheral.writeValue(value, for: characteristic, type: type)
         }
 
-        guard let value = characteristic.value else {
+        let value = characteristic.value
+
+        guard !characteristic.isNotifying || value != nil else {
             // TODO: This is an "unknown value" issue, not a timeout
             throw PeripheralManagerError.timeout
         }
 
-        return value
+        return value ?? Data()
     }
 }
 

--- a/xDripG5/Transmitter.swift
+++ b/xDripG5/Transmitter.swift
@@ -247,27 +247,17 @@ fileprivate extension PeripheralManager {
             throw TransmitterError.authenticationError("Error writing keep-alive for bond: \(error)")
         }
 
-        let data: Data
         do {
-            // Wait for the OS dialog to pop-up before continuing.
             _ = try writeValue(BondRequestTxMessage().data, for: .authentication)
-            data = try readValue(for: .authentication, timeout: 15, expectingFirstByte: AuthStatusRxMessage.opcode)
         } catch let error {
             throw TransmitterError.authenticationError("Error writing bond request: \(error)")
-        }
-
-        guard let response = AuthStatusRxMessage(data: data) else {
-            throw TransmitterError.authenticationError("Unable to parse auth status: \(data)")
-        }
-
-        guard response.bonded == 0x1 else {
-            throw TransmitterError.authenticationError("Transmitter failed to bond")
         }
     }
 
     func control() throws -> Glucose {
         do {
-            try setNotifyValue(true, for: .control)
+            // Wait for the up to 15s for the user to respond to the pairing request.
+            try setNotifyValue(true, for: .control, timeout: 15)
         } catch let error {
             throw TransmitterError.controlError("Error enabling notification: \(error)")
         }

--- a/xDripG5/Transmitter.swift
+++ b/xDripG5/Transmitter.swift
@@ -256,7 +256,7 @@ fileprivate extension PeripheralManager {
 
     func control() throws -> Glucose {
         do {
-            // Wait for the up to 15s for the user to respond to the pairing request.
+            // Wait for up to 15s for the user to respond to the pairing request.
             try setNotifyValue(true, for: .control, timeout: 15)
         } catch let error {
             throw TransmitterError.controlError("Error enabling notification: \(error)")


### PR DESCRIPTION
This PR fixes a few issues with authentication and bonding.

1. In `PeripheralManager+G5.swift` writing to a characteristic that is not notifying should not throw and should return a `Data` object with zero bytes. Was previously failing a guard statement due to `characteristic.value == nil`.

2. `AppDelegate.swift` was calling `transmitter.resumeScanning` on `applicationDidBecomeActive`. This causes undesired behaviour. For example the function is called when the user accepts the pairing request, causing the transmitter to immediately disconnect. This PR only calls `resumeScanning` if `!transmitter.stayConnected`.

3. After sending a bond request message, the auth characteristic does not respond to any read or write commands. Consequently [this line](https://github.com/LoopKit/xDripG5/blob/fe93d4759b9cba9f106cffb53fe3b383e0b9a6db/xDripG5/Transmitter.swift#L254) always throws with a timeout error. Also, since the auth characteristic is not notifying, there is no way to be informed whether the user has accepted the pairing request. In this change we no longer try to query the auth status after bonding; rather we progress immediately to control, and allow the first step in control to timeout after 15s rather than the default 2. The result is that the control step proceeds once the user accepts the pairing request. If the user doesn't accept the pairing request, the transmitter simply disconnects and we have another chance on the next transmitter wakeup.

Also fixes debug messages like "Re-connecting to known peripheral #### in 4640537203540230144s" (string format specifier).