### PR TITLE
fix issue with central manager on transmitter ID change

### DIFF
--- a/xDripG5/BluetoothManager.swift
+++ b/xDripG5/BluetoothManager.swift
@@ -156,11 +156,6 @@ class BluetoothManager: NSObject {
         }
     }
 
-    deinit {
-        stayConnected = false
-        disconnect()
-    }
-
     // MARK: - Accessors
 
     var isScanning: Bool {


### PR DESCRIPTION
The latest changes to dev create a new Transmitter object whenever the transmitter ID is set. However, when the ID is changed in the example app, I have found that the central manager state is `.unsupported` on `didUpdateState` and the app does not scan for BLE devices (on iOS 11.2.5). On the next ID change the central manager state is `.poweredOn`, as expected.

As suggested by @ps2, this change removes the call to `disconnect()` on deinit (and removes deinit; it doesn't do anything). With this change the central manager does not enter the `.unsupported` state and the app reliably scans on changes to ID.