### PR TITLE
support sensor start, stop, calibrate

### DIFF
--- a/CGMBLEKit Example/AppDelegate.swift
+++ b/CGMBLEKit Example/AppDelegate.swift
@@ -31,10 +31,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
 
                 UserDefaults.standard.transmitterID = id
             }
+            glucose = nil
         }
     }
 
     var transmitter: Transmitter?
+
+    var glucose: Glucose?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
@@ -91,6 +94,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TransmitterDelegate {
     }
 
     func transmitter(_ transmitter: Transmitter, didRead glucose: Glucose) {
+        self.glucose = glucose
         DispatchQueue.main.async {
             if let vc = self.window?.rootViewController as? TransmitterDelegate {
                 vc.transmitter(transmitter, didRead: glucose)

--- a/CGMBLEKit Example/ViewController.swift
+++ b/CGMBLEKit Example/ViewController.swift
@@ -32,6 +32,66 @@ class ViewController: UIViewController, TransmitterDelegate, UITextFieldDelegate
         stayConnectedSwitch.isOn = AppDelegate.sharedDelegate.transmitter?.stayConnected ?? false
 
         transmitterIDField.text = AppDelegate.sharedDelegate.transmitter?.ID
+
+        titleLabel.isUserInteractionEnabled = true
+
+        let glucoseTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(ViewController.chooseAction))
+        titleLabel.addGestureRecognizer(glucoseTapGestureRecognizer)
+    }
+
+    @objc func chooseAction(sender: UITapGestureRecognizer) {
+        guard let glucose = AppDelegate.sharedDelegate.glucose else {
+            return
+        }
+
+        switch glucose.state {
+        case .stopped:
+            startSensor()
+        case .needFirstInitialCalibration, .needSecondInitialCalibration, .ok, .needCalibration:
+            calibrateSensor()
+        default:
+            break
+        }
+    }
+
+    func startSensor() {
+        let dialog = UIAlertController(title: "Confirm", message: "Start sensor session.", preferredStyle: .alert)
+
+        dialog.addAction(UIAlertAction(title: "OK", style: .default, handler: { (action: UIAlertAction!) in
+            self.titleLabel.text = "starting..."
+            AppDelegate.sharedDelegate.transmitter?.startSensor()
+        }))
+
+        dialog.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        present(dialog, animated: true, completion: nil)
+    }
+
+    func calibrateSensor() {
+        let dialog = UIAlertController(title: "Enter BG", message: "Calibrate sensor.", preferredStyle: .alert)
+
+        dialog.addTextField { (textField : UITextField!) in
+            textField.placeholder = "Enter BG"
+            textField.keyboardType = .numberPad
+        }
+
+        dialog.addAction(UIAlertAction(title: "Calibrate", style: .default, handler: { (action: UIAlertAction!) in
+            let textField = dialog.textFields![0] as UITextField
+
+            if let text = textField.text, let entry = Int(text) {
+                guard entry >= 40 && entry <= 400 else {
+                    // TODO: notify the user if the glucose is not in range
+                    return
+                }
+                let unit = HKUnit.milligramsPerDeciliter()
+                let glucose = HKQuantity(unit: unit, doubleValue: Double(entry))
+                AppDelegate.sharedDelegate.transmitter?.calibrateSensor(glucose)
+            }
+        }))
+
+        dialog.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        present(dialog, animated: true, completion: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -133,4 +193,3 @@ private extension NSRange {
         return startIndex..<endIndex
     }
 }
-

--- a/xDripG5.xcodeproj/project.pbxproj
+++ b/xDripG5.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		C19084BB203932BD00AA47F3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C19084B9203932BD00AA47F3 /* Main.storyboard */; };
 		C1CD8B0B203931AD00A8F498 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CD8B09203931AD00A8F498 /* Data.swift */; };
 		C1CD8B0C203931AD00A8F498 /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1CD8B0A203931AD00A8F498 /* NSUserDefaults.swift */; };
+		E75DB6AE20419B5D00FBE04E /* CalibrateGlucoseRxMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75DB6AD20419B5D00FBE04E /* CalibrateGlucoseRxMessage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -174,6 +175,7 @@
 		C19084BA203932BD00AA47F3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C1CD8B09203931AD00A8F498 /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		C1CD8B0A203931AD00A8F498 /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
+		E75DB6AD20419B5D00FBE04E /* CalibrateGlucoseRxMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrateGlucoseRxMessage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -302,6 +304,7 @@
 				43CE7CCB1CA73BCC003CC1B0 /* BatteryStatusTxMessage.swift */,
 				43CABE1B1C350B3D00005705 /* BondRequestTxMessage.swift */,
 				43CE7CD11CA73CBC003CC1B0 /* CalibrateGlucoseTxMessage.swift */,
+				E75DB6AD20419B5D00FBE04E /* CalibrateGlucoseRxMessage.swift */,
 				43846AC51D8F896C00799272 /* CalibrationDataRxMessage.swift */,
 				43CABE1C1C350B3D00005705 /* DisconnectTxMessage.swift */,
 				43CE7CC71CA73AEB003CC1B0 /* FirmwareVersionTxMessage.swift */,
@@ -510,6 +513,7 @@
 				43CABE2E1C350B3D00005705 /* TransmitterTimeTxMessage.swift in Sources */,
 				43880F981D9E19FC009061A8 /* TransmitterVersionRxMessage.swift in Sources */,
 				43CABE2C1C350B3D00005705 /* TransmitterMessage.swift in Sources */,
+				E75DB6AE20419B5D00FBE04E /* CalibrateGlucoseRxMessage.swift in Sources */,
 				43CABE131C350B2800005705 /* BluetoothServices.swift in Sources */,
 				43E3978F1D566B170028E321 /* Glucose.swift in Sources */,
 				43CABE151C350B2800005705 /* Transmitter.swift in Sources */,

--- a/xDripG5/Messages/CalibrateGlucoseRxMessage.swift
+++ b/xDripG5/Messages/CalibrateGlucoseRxMessage.swift
@@ -1,0 +1,24 @@
+//
+//  CalibrateGlucoseRxMessage.swift
+//  xDripG5
+//
+//  Created by Paul Dickens on 25/02/2018.
+//  Copyright © 2018 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+
+public struct CalibrateGlucoseRxMessage: TransmitterRxMessage {
+    static let opcode: UInt8 = 0x35
+
+    init?(data: Data) {
+        guard data.count == 5 && data.crcValid() else {
+            return nil
+        }
+
+        guard data[0] == type(of: self).opcode else {
+            return nil
+        }
+    }
+}

--- a/xDripG5/Messages/CalibrateGlucoseTxMessage.swift
+++ b/xDripG5/Messages/CalibrateGlucoseTxMessage.swift
@@ -9,6 +9,18 @@
 import Foundation
 
 
-struct CalibrateGlucoseTxMessage {
+struct CalibrateGlucoseTxMessage: TimedTransmitterTxMessage {
+    static func createRxMessage(data: Data) -> TransmitterRxMessage? {
+        return CalibrateGlucoseRxMessage(data: data)
+    }
+
     let opcode: UInt8 = 0x34
+    let date: Date
+    let glucose: UInt16
+
+    func data(activationDate: Date) -> Data {
+        let calibrationTime = UInt32(date.timeIntervalSince(activationDate))
+        let byteSequence: [Any] = [opcode, glucose, calibrationTime]
+        return Data.fromByteSequence(byteSequence, hasCRC: true)
+    }
 }

--- a/xDripG5/Messages/GlucoseTxMessage.swift
+++ b/xDripG5/Messages/GlucoseTxMessage.swift
@@ -11,8 +11,9 @@ import Foundation
 
 struct GlucoseTxMessage: TransmitterTxMessage {
     let opcode: UInt8 = 0x30
+    let hasCRC = true
 
     var byteSequence: [Any] {
-        return [opcode, opcode.crc16()]
+        return [opcode]
     }
 }

--- a/xDripG5/Messages/SessionStartRxMessage.swift
+++ b/xDripG5/Messages/SessionStartRxMessage.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-struct SessionStartRxMessage {
+struct SessionStartRxMessage: TransmitterRxMessage {
     static let opcode: UInt8 = 0x27
     let status: UInt8
     let received: UInt8

--- a/xDripG5/Messages/SessionStartTxMessage.swift
+++ b/xDripG5/Messages/SessionStartTxMessage.swift
@@ -9,11 +9,18 @@
 import Foundation
 
 
-struct SessionStartTxMessage: TransmitterTxMessage {
-    let opcode: UInt8 = 0x26
-    let startTime: UInt32
+struct SessionStartTxMessage: TimedTransmitterTxMessage {
+    static func createRxMessage(data: Data) -> TransmitterRxMessage? {
+        return SessionStartRxMessage(data: data)
+    }
 
-    var byteSequence: [Any] {
-        return [opcode, startTime]
+    let opcode: UInt8 = 0x26
+    let date: Date
+
+    func data(activationDate: Date) -> Data {
+        let startTime: UInt32 = UInt32(date.timeIntervalSince(activationDate))
+        let startTimeEpoch: UInt32 = UInt32(date.timeIntervalSince1970)
+        let byteSequence: [Any] = [opcode, startTime, startTimeEpoch]
+        return Data.fromByteSequence(byteSequence, hasCRC: true)
     }
 }

--- a/xDripG5/Messages/SessionStopRxMessage.swift
+++ b/xDripG5/Messages/SessionStopRxMessage.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-struct SessionStopRxMessage {
+struct SessionStopRxMessage: TransmitterRxMessage {
     static let opcode: UInt8 = 0x29
     let status: UInt8
     let received: UInt8

--- a/xDripG5/Messages/SessionStopTxMessage.swift
+++ b/xDripG5/Messages/SessionStopTxMessage.swift
@@ -9,11 +9,17 @@
 import Foundation
 
 
-struct SessionStopTxMessage: TransmitterTxMessage {
-    let opcode: UInt8 = 0x28
-    let stopTime: UInt32
+struct SessionStopTxMessage: TimedTransmitterTxMessage {
+    static func createRxMessage(data: Data) -> TransmitterRxMessage? {
+        return SessionStopRxMessage(data: data)
+    }
 
-    var byteSequence: [Any] {
-        return [opcode, stopTime]
+    let opcode: UInt8 = 0x28
+    let date: Date
+
+    func data(activationDate: Date) -> Data {
+        let stopTime = UInt32(date.timeIntervalSince(activationDate))
+        let byteSequence: [Any] = [opcode, stopTime]
+        return Data.fromByteSequence(byteSequence, hasCRC: true)
     }
 }

--- a/xDripG5/Messages/TransmitterMessage.swift
+++ b/xDripG5/Messages/TransmitterMessage.swift
@@ -15,11 +15,23 @@ protocol TransmitterTxMessage {
 
     var data: Data { get }
 
-}
+    var hasCRC: Bool { get }
 
+}
 
 extension TransmitterTxMessage {
     var data: Data {
+        return Data.fromByteSequence(byteSequence, hasCRC: hasCRC)
+    }
+
+    var hasCRC: Bool {
+        return false
+    }
+}
+
+
+extension Data {
+    static func fromByteSequence(_ byteSequence: [Any], hasCRC: Bool = false) -> Data {
         let data = NSMutableData()
 
         for item in byteSequence {
@@ -47,8 +59,24 @@ extension TransmitterTxMessage {
             }
         }
 
+        if hasCRC {
+            var value = (data as Data).crc16() as UInt16
+            data.append(&value, length: 2)
+        }
+
         return data as Data
     }
+}
+
+
+protocol TimedTransmitterTxMessage {
+
+    static func createRxMessage(data: Data) -> TransmitterRxMessage?
+
+    var opcode: UInt8 { get }
+
+    func data(activationDate: Date) -> Data
+
 }
 
 

--- a/xDripG5/Messages/TransmitterTimeTxMessage.swift
+++ b/xDripG5/Messages/TransmitterTimeTxMessage.swift
@@ -11,8 +11,9 @@ import Foundation
 
 struct TransmitterTimeTxMessage: TransmitterTxMessage {
     let opcode: UInt8 = 0x24
+    let hasCRC = true
 
     var byteSequence: [Any] {
-        return [opcode, opcode.crc16()]
+        return [opcode]
     }
 }

--- a/xDripG5/Transmitter.swift
+++ b/xDripG5/Transmitter.swift
@@ -316,7 +316,7 @@ fileprivate extension PeripheralManager {
 
         let activationDate = Date(timeIntervalSinceNow: -TimeInterval(timeMessage.currentTime))
 
-        while var message = getMessage() {
+        while let message = getMessage() {
             let data: Data
             do {
                 data = try writeValue(message.data(activationDate: activationDate), for: .control, expectingFirstByte: message.opcode + 1)


### PR DESCRIPTION
This PR adds support for starting, stopping and calibrating sensors for in-date transmitters.
 - Create new protocol `TimedTransmitterTxMessage`, with a `date` and that requires an `activationDate` from the transmitter for synchronisation. `SessionStartTxMessage`, `SessionStopTxMessage` and `CalibrateGlucoseTxMessage` now conform to this protocol.
 - Add message queue to `Transmitter`, which holds any user-initiated messages for processing at the next sensor read. This queue is processed in the control step.
 - Add new message `CalibrateGlucoseRxMessage`.
 - Append CRC (if used) after converting byte sequence to `Data` (for longer messages).
 - Add public functions `startSensor`, `stopSensor` and `calibrateSensor` to `Transmitter`
 - Add UI for starting a session and calibrating a sensor in Example app.